### PR TITLE
Add workdir awareness script and integrate into PM tools

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,3 +63,4 @@ Using the test-runner agent ensures:
 - NO OVER-ENGINEERING - Don't add unnecessary abstractions, factory patterns, or middleware when simple functions would work. Don't think "enterprise" when you need "working"
 - NO MIXED CONCERNS - Don't put validation logic inside API handlers, database queries inside UI components, etc. instead of proper separation
 - NO RESOURCE LEAKS - Don't forget to close database connections, clear timeouts, remove event listeners, or clean up file handles
+- ALWAYS RUN `.claude/scripts/pm/workdir-type.sh` at the start of each development interaction and show its output to the user

--- a/.claude/rules/worktree-operations.md
+++ b/.claude/rules/worktree-operations.md
@@ -18,6 +18,12 @@ The worktree will be created as a sibling directory to maintain clean separation
 
 ## Working in Worktrees
 
+Before making any edits or commits, verify where you are working:
+
+```bash
+./.claude/scripts/pm/workdir-type.sh
+```
+
 ### Agent Commits
 - Agents commit directly to the worktree
 - Use small, focused commits

--- a/.claude/scripts/pm/blocked.sh
+++ b/.claude/scripts/pm/blocked.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/workdir-type.sh"
+echo ""
 echo "Getting tasks..."
 echo ""
 echo ""

--- a/.claude/scripts/pm/in-progress.sh
+++ b/.claude/scripts/pm/in-progress.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/workdir-type.sh"
+echo ""
 echo "Getting status..."
 echo ""
 echo ""

--- a/.claude/scripts/pm/status.sh
+++ b/.claude/scripts/pm/status.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/workdir-type.sh"
+echo ""
 echo "Getting status..."
 echo ""
 echo ""

--- a/.claude/scripts/pm/workdir-type.sh
+++ b/.claude/scripts/pm/workdir-type.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ]; then
+  echo "❌ Not inside a git repository"
+  exit 1
+fi
+
+main_repo=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+
+if [ "$repo_root" = "$main_repo" ]; then
+  echo "✅ Working in main repository"
+else
+  rel_path=$(realpath --relative-to="$main_repo" "$repo_root")
+  echo "✅ Working in worktree: $rel_path"
+fi


### PR DESCRIPTION
## Summary
- add `workdir-type.sh` to report whether the current directory is the main repo or a worktree
- require running the new script before edits via worktree operations and CLAUDE guidelines
- show worktree context automatically from status, in-progress, and blocked PM scripts
- integrate workdir awareness into CLAUDE absolute rules

## Testing
- `.claude/scripts/pm/workdir-type.sh`
- `.claude/scripts/pm/status.sh`
- `.claude/scripts/pm/in-progress.sh`
- `.claude/scripts/pm/blocked.sh`
- `.claude/scripts/pm/validate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc064c030c832494226f8f3e83612c